### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/routes/files.py
+++ b/backend/app/routes/files.py
@@ -154,17 +154,25 @@ async def download_data_file(filename: str):
     """
     # Search for file in cache directories
     possible_paths = [
-        os.path.join(CACHE_DIR, filename),
-        os.path.join(CACHE_DIR, "crypto", filename),
-        os.path.join(CACHE_DIR, "etf", filename),
-        os.path.join(DATA_DIR, filename)
+        os.path.normpath(os.path.join(CACHE_DIR, filename)),
+        os.path.normpath(os.path.join(CACHE_DIR, "crypto", filename)),
+        os.path.normpath(os.path.join(CACHE_DIR, "etf", filename)),
+        os.path.normpath(os.path.join(DATA_DIR, filename))
     ]
     
     file_path = None
     for path in possible_paths:
-        if os.path.exists(path):
-            file_path = path
-            break
+        # Ensure the path is within the allowed directories
+        if path.startswith(CACHE_DIR) or path.startswith(DATA_DIR):
+            if os.path.exists(path):
+                file_path = path
+                break
+    
+    if not file_path:
+        raise HTTPException(
+            status_code=404, 
+            detail=f"Data file '{filename}' not found or access denied"
+        )
     
     if not file_path:
         raise HTTPException(


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/trading-mvp/security/code-scanning/2](https://github.com/dock108/trading-mvp/security/code-scanning/2)

To fix the issue, we need to validate and sanitize the `filename` parameter to ensure that it does not allow access to files outside the intended directories. The best approach is to normalize the constructed paths using `os.path.normpath` and verify that they are confined within the allowed directories. This ensures that even if the user provides malicious input like `../../../etc/passwd`, the code will reject it.

Steps to implement the fix:
1. Normalize each constructed path using `os.path.normpath`.
2. Check that the normalized path starts with one of the allowed base directories (`CACHE_DIR` or `DATA_DIR`).
3. Raise an exception if the path is not valid.
4. Ensure that the fix does not alter existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
