### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/routes/files.py
+++ b/backend/app/routes/files.py
@@ -162,10 +162,12 @@ async def download_data_file(filename: str):
     
     file_path = None
     for path in possible_paths:
-        # Ensure the path is within the allowed directories
-        if path.startswith(CACHE_DIR) or path.startswith(DATA_DIR):
-            if os.path.exists(path):
-                file_path = path
+        # Normalize the path to prevent path traversal attacks
+        normalized_path = os.path.normpath(path)
+        # Ensure the normalized path is within the allowed directories
+        if normalized_path.startswith(CACHE_DIR) or normalized_path.startswith(DATA_DIR):
+            if os.path.exists(normalized_path):
+                file_path = normalized_path
                 break
     
     if not file_path:


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/trading-mvp/security/code-scanning/2](https://github.com/dock108/trading-mvp/security/code-scanning/2)

To fix the issue, we need to ensure that the paths constructed from user input are normalized before validating them. This can be achieved by using `os.path.normpath` to resolve any `..` sequences or redundant separators in the path. After normalization, we can verify that the resulting path is contained within the allowed directories (`CACHE_DIR` or `DATA_DIR`). If the normalized path does not start with one of these directories, we should reject the request.

The changes will involve:
1. Normalizing the `path` variable in the loop on line 164 before performing the `startswith` check.
2. Ensuring that the normalized path is used for both validation and subsequent operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
