### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/routes/files.py
+++ b/backend/app/routes/files.py
@@ -155,6 +155,12 @@ async def download_data_file(filename: str):
     """
     # Sanitize the filename to prevent path traversal attacks
     safe_filename = secure_filename(filename)
+    # Validate that the sanitized filename is not empty
+    if not safe_filename:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid filename provided"
+        )
     
     # Search for file in cache directories
     possible_paths = [

--- a/backend/app/routes/files.py
+++ b/backend/app/routes/files.py
@@ -10,6 +10,7 @@ from typing import List
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from fastapi.responses import FileResponse
 import yaml
+from werkzeug.utils import secure_filename
 
 router = APIRouter()
 
@@ -152,12 +153,15 @@ async def download_data_file(filename: str):
     Args:
         filename: Name of the file to download
     """
+    # Sanitize the filename to prevent path traversal attacks
+    safe_filename = secure_filename(filename)
+    
     # Search for file in cache directories
     possible_paths = [
-        os.path.normpath(os.path.join(CACHE_DIR, filename)),
-        os.path.normpath(os.path.join(CACHE_DIR, "crypto", filename)),
-        os.path.normpath(os.path.join(CACHE_DIR, "etf", filename)),
-        os.path.normpath(os.path.join(DATA_DIR, filename))
+        os.path.normpath(os.path.join(CACHE_DIR, safe_filename)),
+        os.path.normpath(os.path.join(CACHE_DIR, "crypto", safe_filename)),
+        os.path.normpath(os.path.join(CACHE_DIR, "etf", safe_filename)),
+        os.path.normpath(os.path.join(DATA_DIR, safe_filename))
     ]
     
     file_path = None
@@ -174,21 +178,15 @@ async def download_data_file(filename: str):
     if not file_path:
         raise HTTPException(
             status_code=404, 
-            detail=f"Data file '{filename}' not found or access denied"
-        )
-    
-    if not file_path:
-        raise HTTPException(
-            status_code=404, 
-            detail=f"Data file '{filename}' not found"
+            detail=f"Data file '{safe_filename}' not found or access denied"
         )
     
     # Determine media type based on file extension
-    if filename.endswith('.csv'):
+    if safe_filename.endswith('.csv'):
         media_type = 'text/csv'
-    elif filename.endswith('.json'):
+    elif safe_filename.endswith('.json'):
         media_type = 'application/json'
-    elif filename.endswith(('.yaml', '.yml')):
+    elif safe_filename.endswith(('.yaml', '.yml')):
         media_type = 'application/x-yaml'
     else:
         media_type = 'application/octet-stream'
@@ -196,7 +194,7 @@ async def download_data_file(filename: str):
     return FileResponse(
         path=file_path,
         media_type=media_type,
-        filename=filename
+        filename=safe_filename
     )
 
 @router.get("/list/data")

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ python-multipart>=0.0.6  # For file upload support
 # pytest>=7.4.0          # Testing framework
 # pytest-mock>=3.11.1    # Mocking for tests
 # responses>=0.23.1       # Mock HTTP responses for testing
+werkzeug==3.1.3


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/trading-mvp/security/code-scanning/2](https://github.com/dock108/trading-mvp/security/code-scanning/2)

To fix the issue, we need to ensure that the `filename` parameter is sanitized and validated rigorously before constructing file paths. The best approach is to:
1. Use `werkzeug.utils.secure_filename` to sanitize the `filename` input, removing any special characters or sequences that could lead to path traversal.
2. Combine the sanitized filename with the base directory using `os.path.join` and normalize the resulting path.
3. Validate that the normalized path is strictly within the allowed directories (`CACHE_DIR` or `DATA_DIR`) using `os.path.commonpath`.

This fix ensures that the filename is safe and that the constructed path cannot escape the intended directories.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
